### PR TITLE
frameworks/wasm:Wasm Interrupt Control Code 2.0

### DIFF
--- a/irq/CMakeLists.txt
+++ b/irq/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/examples/wamr_module/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+if(CONFIG_WASM_IRQ)
+  target_sources(apps PRIVATE wasm_irq_manager.c)
+  target_sources(apps PRIVATE wasm_irq.c)
+  # register WAMR mod
+  nuttx_add_wamrmod(MODS irq)
+endif()

--- a/irq/Kconfig
+++ b/irq/Kconfig
@@ -1,0 +1,22 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config  WASM_IRQ
+	bool "WASM IRQ configure"
+	default n
+	---help---
+		Control Wasm IRQ thread compilation switch configuration.
+
+if WASM_IRQ
+
+config WASM_IRQ_THREAD_PRIORITY
+        int "Webassembly IRQ thread priority"
+        default 100
+
+config WASM_IRQ_THREAD_STACK_SIZE
+        int "Webassembly IRQ thread stack size"
+        default 2048
+
+endif

--- a/irq/Make.defs
+++ b/irq/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/audioutils/nxaudio/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_WASM_IRQ),)
+CONFIGURED_APPS += $(APPDIR)/frameworks/wasm/irq
+endif

--- a/irq/Makefile
+++ b/irq/Makefile
@@ -1,0 +1,31 @@
+############################################################################
+# apps/audioutils/nxaudio/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+ifeq ($(CONFIG_WASM_IRQ),y)
+CSRCS  +=  wasm_irq_manager.c
+CSRCS  +=  wasm_irq.c
+endif
+
+WAMR_MODULE_NAME = irq
+
+include $(APPDIR)/interpreters/wamr/Module.mk
+include $(APPDIR)/Application.mk

--- a/irq/wasm_irq.c
+++ b/irq/wasm_irq.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <nuttx/arch.h>
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+#include <semaphore.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <syslog.h>
+
+#include "wasm_irq_manager.h"
+
+static int __wasm_irq_hander(int irq, void* context, void* arg)
+{
+    wasm_irq_t* p = (wasm_irq_t*)arg;
+
+    atomic_fetch_add_explicit(&p->refs, 1, memory_order_relaxed);
+    if (p->irq_thread->irq_status == WASM_IRQ_STOP) {
+        up_disable_irq(p->id);
+        sem_post(&p->irq_thread->wasm_irq_sem);
+    }
+
+    return 0;
+}
+
+static int irq_attach_wrapper(wasm_exec_env_t exec_env, int irq, unsigned int index, unsigned int arg)
+{
+    int ret;
+    wasm_irq_t* node;
+    node = wasm_interrupt_register(irq, wasm_runtime_get_user_data(exec_env), index, arg);
+    if (!node) {
+        ret = get_errno();
+        return ret;
+    }
+
+    ret = irq_attach(irq, __wasm_irq_hander, node);
+    return ret;
+}
+
+static void irq_enable_wrapper(wasm_exec_env_t exec_env, int irq)
+{
+    up_enable_irq(irq);
+}
+
+static void irq_disable_wrapper(wasm_exec_env_t exec_env, int irq)
+{
+    up_disable_irq(irq);
+}
+
+static void irq_initialize_wrapper(wasm_exec_env_t exec_env)
+{
+    int ret;
+    wasm_irq_thread* wasm_thread = NULL;
+
+    wasm_thread = (wasm_irq_thread*)malloc(sizeof(wasm_irq_thread));
+    if (wasm_thread == NULL) {
+        syslog(LOG_ERR, "wasm_irq_thread malloc failed \n");
+        return;
+    }
+
+    wasm_module_inst_t module_inst = get_module_inst(exec_env);
+    ret = wasm_irq_thread_create(module_inst, wasm_thread);
+    if (ret != 0) {
+        syslog(LOG_ERR, "create irq pthread err\n");
+        free(wasm_thread);
+    } else {
+        wasm_runtime_set_user_data(exec_env, (void*)wasm_thread);
+    }
+}
+
+static void irq_uninitialize_wrapper(wasm_exec_env_t exec_env)
+{
+    wasm_irq_thread_exit(wasm_runtime_get_user_data(exec_env));
+    free(wasm_runtime_get_user_data(exec_env));
+}
+
+static NativeSymbol g_wasm_symbols_irq[] = {
+    EXPORT_WASM_API_WITH_SIG2(irq_attach, "(iii)i"),
+    EXPORT_WASM_API_WITH_SIG2(irq_enable, "(i)"),
+    EXPORT_WASM_API_WITH_SIG2(irq_disable, "(i)"),
+    EXPORT_WASM_API_WITH_SIG2(irq_initialize, "()"),
+    EXPORT_WASM_API_WITH_SIG2(irq_uninitialize, "()"),
+};
+
+bool wamr_module_irq_register(void)
+{
+    return wasm_runtime_register_natives("env", g_wasm_symbols_irq,
+        nitems(g_wasm_symbols_irq));
+}

--- a/irq/wasm_irq_manager.c
+++ b/irq/wasm_irq_manager.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <nuttx/config.h>
+#include <nuttx/pthread.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <syslog.h>
+
+#include "wasm_irq_manager.h"
+
+void* wasm_irq_thread_cb(void* arg)
+{
+    wasm_irq_t* node;
+    wasm_irq_t* temp;
+    wasm_irq_thread* wasm_thread = (wasm_irq_thread*)arg;
+    bool flag = false;
+
+    if (!wasm_runtime_init_thread_env()) {
+        return NULL;
+    }
+
+    while (!wasm_thread->irq_exit) {
+        flag = false;
+        if (!list_is_empty(&wasm_thread->irq_list)) {
+            list_for_every_entry_safe(&wasm_thread->irq_list, node, temp, struct wasm_irq_s, list)
+            {
+                if (node->status == WASM_IRQ_STATUS_RELEASED) {
+                    list_delete(&node->list);
+                    free(node);
+                    continue;
+                }
+
+                if (node->refs > 0) {
+                    if (!wasm_runtime_call_indirect(wasm_thread->exec_env, node->index, 1, (uint32_t*)node->arg)) {
+                        wasm_thread->irq_exit = true;
+                        break;
+                    }
+                    atomic_fetch_sub_explicit(&node->refs, 1, memory_order_relaxed);
+                    continue;
+                }
+            }
+
+            list_for_every_entry(&wasm_thread->irq_list, node, struct wasm_irq_s, list)
+            {
+                if (node->refs > 0) {
+                    flag = true;
+                    break;
+                }
+            }
+        }
+
+        if (!flag && wasm_thread->irq_exit == false) {
+            atomic_store_explicit(&wasm_thread->irq_status, WASM_IRQ_STOP, memory_order_relaxed);
+            sem_wait(&wasm_thread->wasm_irq_sem);
+            atomic_store_explicit(&wasm_thread->irq_status, WASM_IRQ_RUN, memory_order_relaxed);
+        }
+    }
+
+    wasm_runtime_destroy_thread_env();
+    return NULL;
+}
+
+static wasm_irq_t* wasm_interrupt_malloc(void)
+{
+    return malloc(sizeof(wasm_irq_t));
+}
+
+wasm_irq_t* wasm_interrupt_register(int irq, wasm_irq_thread* wasm_thread, unsigned int index, unsigned int arg)
+{
+    wasm_irq_t* node;
+    if (!wasm_thread->is_irq_enable) {
+        set_errno(-EINVAL);
+        return NULL;
+    }
+
+    if (!list_is_empty(&wasm_thread->irq_list)) {
+        list_for_every_entry(&wasm_thread->irq_list, node, struct wasm_irq_s, list)
+        {
+            if (node->status != WASM_IRQ_STATUS_RELEASED && node->id == irq) {
+                set_errno(-EEXIST);
+                return NULL;
+            }
+        }
+    }
+
+    node = wasm_interrupt_malloc();
+    if (!node) {
+        set_errno(-ENOMEM);
+        return NULL;
+    }
+
+    node->status = 0;
+    node->id = irq;
+    node->refs = 0;
+    node->index = index;
+    node->arg[0] = arg;
+    node->irq_thread = wasm_thread;
+
+    list_add_tail(&wasm_thread->irq_list, &node->list);
+
+    return node;
+}
+
+void wasm_interrupt_unregister(int irq, wasm_irq_thread* wasm_thread)
+{
+    wasm_irq_t* node;
+    wasm_irq_t* temp;
+
+    if (!wasm_thread->is_irq_enable) {
+        return;
+    }
+
+    if (list_is_empty(&wasm_thread->irq_list)) {
+        return;
+    }
+    syslog(LOG_INFO, "wasm_interrupt_unregister start!!");
+    list_for_every_entry_safe(&wasm_thread->irq_list, node, temp, struct wasm_irq_s, list)
+    {
+        if (node->id == irq) {
+            node->status = WASM_IRQ_STATUS_RELEASED;
+            if (wasm_thread->irq_status == WASM_IRQ_STOP) {
+                sem_post(&wasm_thread->wasm_irq_sem);
+            }
+        }
+    }
+}
+
+int wasm_irq_thread_create(wasm_module_inst_t inst, wasm_irq_thread* wasm_thread)
+{
+    int ret = -EINVAL;
+    pthread_attr_t attr = { 0 };
+
+    wasm_thread->exec_env = wasm_runtime_create_exec_env(inst, 4);
+    if (!wasm_thread->exec_env) {
+        return ret;
+    }
+
+    wasm_thread->spawn_exec_env = wasm_runtime_spawn_exec_env(wasm_thread->exec_env);
+    if (!wasm_thread->spawn_exec_env) {
+        wasm_runtime_destroy_exec_env(wasm_thread->exec_env);
+        return ret;
+    }
+
+    list_initialize(&wasm_thread->irq_list);
+    sem_init(&wasm_thread->wasm_irq_sem, 1, 0);
+    wasm_thread->irq_status = WASM_IRQ_STOP;
+    wasm_thread->irq_exit = false;
+
+    memcpy(&attr, &g_default_pthread_attr, sizeof(pthread_attr_t));
+    attr.priority = CONFIG_WASM_IRQ_THREAD_PRIORITY;
+    attr.stacksize = CONFIG_WASM_IRQ_THREAD_STACK_SIZE;
+
+    ret = pthread_create(&wasm_thread->pt_irq, &attr, wasm_irq_thread_cb, (void*)wasm_thread);
+    if (ret == 0) {
+        pthread_setname_np(wasm_thread->pt_irq, "wasm_irq");
+        pthread_attr_destroy(&attr);
+        wasm_thread->is_irq_enable = true;
+    } else {
+        wasm_runtime_destroy_spawned_exec_env(wasm_thread->spawn_exec_env);
+        wasm_runtime_destroy_exec_env(wasm_thread->exec_env);
+        pthread_attr_destroy(&attr);
+        list_clear_node(&wasm_thread->irq_list);
+        sem_destroy(&wasm_thread->wasm_irq_sem);
+    }
+
+    return ret;
+}
+
+void wasm_irq_thread_exit(wasm_irq_thread* wasm_thread)
+{
+    if (wasm_thread->pt_irq < 0) {
+        return;
+    }
+
+    wasm_thread->irq_exit = true;
+    if (wasm_thread->irq_status == WASM_IRQ_STOP) {
+        sem_post(&wasm_thread->wasm_irq_sem);
+    }
+
+    pthread_join(wasm_thread->pt_irq, NULL);
+
+    wasm_thread->irq_status = WASM_IRQ_STOP;
+    list_clear_node(&wasm_thread->irq_list);
+    sem_destroy(&wasm_thread->wasm_irq_sem);
+    wasm_runtime_destroy_spawned_exec_env(wasm_thread->spawn_exec_env);
+    wasm_runtime_destroy_exec_env(wasm_thread->exec_env);
+}

--- a/irq/wasm_irq_manager.h
+++ b/irq/wasm_irq_manager.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __WASM_IRQ_MANAGER__
+#define __WASM_IRQ_MANAGER__
+
+#include <nuttx/list.h>
+#include <nuttx/pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+#include "wasm_export.h"
+
+#define WASM_IRQ_RUN 1
+#define WASM_IRQ_STOP 0
+
+/*
+ * This interrupt needs to be released
+ */
+#define WASM_IRQ_STATUS_RELEASED 1
+
+/**
+ * @struct wasm_irq_thread
+ * @brief Represents a WebAssembly (Wasm) IRQ handling thread structure.
+ *
+ * This structure is used to manage the state and behavior of a thread dedicated to
+ * handling interrupt requests (IRQs) in a WebAssembly runtime environment. It includes
+ * information about the thread's execution state, interrupt status, and synchronization
+ * mechanisms necessary for efficient IRQ processing. Each instance of this structure
+ * corresponds to a specific thread that handles one or more IRQs.
+ *
+ * Members:
+ * - irq_exit: A boolean flag indicating whether the IRQ thread should exit.
+ *   When true, it signals that the thread is requested to terminate its operations.
+ * - is_irq_enable: A boolean flag that determines if interrupts are currently enabled.
+ *   If true, the thread is allowed to process incoming IRQs; if false, it will ignore them.
+ * - pt_irq: A POSIX thread identifier for the IRQ handling thread.
+ *   This ID is utilized for thread management functions, allowing for operations
+ *   such as joining or canceling the thread.
+ * - exec_env: The execution environment for the current thread.
+ *   This structure holds context information needed for executing WebAssembly code.
+ * - spawn_exec_env: The execution environment for any threads that are spawned.
+ *   It allows for the management of separate execution contexts for newly created threads,
+ *   facilitating concurrency in the runtime.
+ * - irq_list: A linked list node used to manage IRQ-related items.
+ *   This enables efficient storage and organization of interrupt requests that
+ *   the thread may need to handle.
+ * - irq_status: An atomic integer representing the current status of interrupts.
+ *   This variable allows for thread-safe updates and reads of the IRQ state,
+ *   preventing race conditions during concurrent access.
+ * - wasm_irq_sem: A semaphore for signaling between threads regarding IRQ events.
+ *   The IRQ thread uses this semaphore to wait for events and to be notified when
+ *   it needs to process an IRQ.
+ */
+
+typedef struct wasm_thread_s {
+    bool irq_exit;
+    bool is_irq_enable;
+    pthread_t pt_irq;
+    wasm_exec_env_t exec_env;
+    wasm_exec_env_t spawn_exec_env;
+    struct list_node irq_list;
+    atomic_int irq_status;
+    sem_t wasm_irq_sem;
+} wasm_irq_thread;
+
+/**
+ * @struct wasm_irq_s
+ * @brief Represents a WebAssembly (Wasm) interrupt request (IRQ) structure.
+ *
+ * This structure is used to manage interrupt requests in a WebAssembly runtime environment.
+ * It holds information related to the interrupt status, reference counting, callback handling,
+ * and associated thread control. Each instance of this structure corresponds to a specific
+ * IRQ identified by its unique ID.
+ *
+ * Members:
+ * - list: A linked list node to facilitate the storage and management of multiple
+ *   wasm_irq_t instances within a collection.
+ * - status: An integer flag indicating the current status of the interrupt,
+ *   allowing for the release or acknowledgment of the interrupt.
+ * - id: A unique identifier for the IRQ, representing its number within the system.
+ * - refs: An atomic integer used for managing the reference count of the structure,
+ *   ensuring safe concurrent access in multi-threaded environments.
+ * - index: An index used to specify the callback address for the Wasm IRQ handler.
+ * - arg: An array of function parameters (with variable length) to be passed to the
+ *   IRQ callback function, allowing for flexible argument handling.
+ * - irq_thread: A pointer to the control structure for the thread associated
+ *   with handling this interrupt, enabling proper synchronization and execution flow.
+ */
+
+typedef struct wasm_irq_s {
+    struct list_node list;
+    int status;
+    unsigned int id;
+    atomic_int refs;
+    unsigned int index;
+    unsigned int arg[1];
+    wasm_irq_thread* irq_thread;
+} wasm_irq_t;
+
+wasm_irq_t* wasm_interrupt_register(int irq, wasm_irq_thread* wasm_thread, unsigned int index, unsigned int arg);
+void wasm_interrupt_unregister(int irq, wasm_irq_thread* wasm_thread);
+void* wasm_irq_thread_cb(void* arg);
+int wasm_irq_thread_create(wasm_module_inst_t inst, wasm_irq_thread* wasm_thread);
+void wasm_irq_thread_exit(wasm_irq_thread* wasm_thread);
+
+#endif

--- a/vela-sysroot/include/vela/irq.h
+++ b/vela-sysroot/include/vela/irq.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corperation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+typedef int (*xcpt_t)(int irq, void* context, void* arg);
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: irq_attach
+ *
+ * Description:
+ *   Configure the IRQ subsystem so that IRQ number 'irq' is dispatched to
+ *   'isr' with argument 'arg'
+ *
+ ****************************************************************************/
+
+int irq_attach(int irq, xcpt_t isr, void* arg);
+
+/****************************************************************************
+ * Name: up_enable_irq
+ *
+ * Description:
+ *   Enable the IRQ specified by 'irq'
+ *
+ ****************************************************************************/
+
+void irq_enable(int irq);
+
+/****************************************************************************
+ * Name: irq_disable
+ *
+ * Description:
+ *   This function must be called from the architecture-specific logic in
+ *   order to dispatch an interrupt to the appropriate, registered handling
+ *   logic.
+ *
+ ****************************************************************************/
+
+void irq_disable(int irq);
+
+/****************************************************************************
+ * Name: irq_initialize
+ *
+ * Description:
+ *   This function is mainly used to create IRQ interrupt threads during
+ *   initialization
+ *
+ ****************************************************************************/
+
+void irq_initialize();
+
+/****************************************************************************
+ * Name: irq_uninitialize
+ *
+ * Description:
+ *   This function mainly releases IRQ thread resources
+ *
+ ****************************************************************************/
+
+void irq_uninitialize();

--- a/vela-sysroot/share/defined-symbols.txt
+++ b/vela-sysroot/share/defined-symbols.txt
@@ -68,3 +68,8 @@ getreg8
 getreg16
 getreg32
 nanosleep
+irq_attach
+irq_enable
+irq_disable
+irq_initialize
+irq_uninitialize

--- a/vendor/bouffalo/CMakeLists.txt
+++ b/vendor/bouffalo/CMakeLists.txt
@@ -105,6 +105,9 @@ add_link_options(-Wl,--gc-sections)
 
 add_library(driver ${DRIVER_SRC})
 
+list(APPEND IRQ_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/irq.c)
+add_library(irq ${IRQ_SRC})
+
 # Adds a WebAssembly application to the build system.
 #
 # This function creates an executable target for the given source files,
@@ -120,6 +123,7 @@ function(add_wasm_application name)
     add_executable(${name} ${SRC})
     set_target_properties(${name} PROPERTIES SUFFIX .wasm)
     target_link_libraries(${name} driver)
+    target_link_libraries(${name} irq)
 
     # Define common parameters for wamrc
     set(WAMRC_COMMON_PARAMS

--- a/vendor/bouffalo/src/irq.c
+++ b/vendor/bouffalo/src/irq.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corperation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vela/irq.h>
+
+#include "bflb_irq.h"
+
+/* Offset 16 is only applicable to BL616 and rel-3.6 branches */
+#define IRQ_OFFSET 16
+
+int bflb_irq_attach(int irq, irq_callback isr, void* arg)
+{
+    return irq_attach(irq + IRQ_OFFSET, (xcpt_t)isr, arg);
+}
+
+void bflb_irq_enable(int irq)
+{
+    irq_enable(irq + IRQ_OFFSET);
+}
+
+void bflb_irq_disable(int irq)
+{
+    irq_disable(irq + IRQ_OFFSET);
+}


### PR DESCRIPTION


## Summary

*Module Independent Dual-core Wasm Interrupt Control*

## Impact

*Usage of Module Independent Secondary Development Version 2.0,encapsulate the low-level interrupt call API, mainly affects the interrupt trigger process.*

## Testing

*cd vela
./build.sh ./vendor/bouffalolab/boards/bl616evb/configs/miot -j9
./build.sh menuconfig and enable following configs: INTERPRETERS_WAMR, INTERPRETERS_WAMR_AOT, INTERPRETERS_WAMR_CONFIGUABLE_BOUNDS_CHECKS, INTERPRETERS_WAMR_CUSTOM_NAME_SECTIONS, INTERPRETERS_WAMR_DUMP_CALL_STACK，INTERPRETERS_WAMR_LIBC_BUILTIN，INTERPRETERS_WAMR_LIB_PTHREAD，INTERPRETERS_WAMR_LOG，INTERPRETERS_WAMR_REF_TYPES，INTERPRETERS_WAMR_SHARED_MEMORY，INTERPRETERS_WAMR_STACKSIZE=32768，INTERPRETERS_WAMR_THREAD_MGR
flashing module
(1)Flash the nuttx.whole.bin to the module chip
(2)start wasm app iwasm --heap-size=4096 --stack-size=2048  /etc/gpio_interrupt.wasm.aot &
(3)Trigger GPIO hardware interrupt by adjusting the high and low levels of GPIO pins*

