### PR TITLE
libc_bypass: Move libc nuttx from apps to frameworks

### DIFF
--- a/libc_bypass/.gitignore
+++ b/libc_bypass/.gitignore
@@ -1,0 +1,3 @@
+syscall_glue.c
+libc_glue.c
+libm_glue.c

--- a/libc_bypass/Kconfig
+++ b/libc_bypass/Kconfig
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+config WASM_LIBC_BYPASS
+    bool "Enable bypass libc to use NuttX system calls"
+    default n
+    ---help---
+        Bypass libc to use NuttX system calls
+
+        If this option is enabled, the libc will be bypassed and the NuttX
+        system calls will be used directly. This only works with bounds check
+        disabled.
+
+if WASM_LIBC_BYPASS
+
+config LIBC_BYPASS_POSIXMEMALIGN_MAP_SIZE
+    int "Set the size for posix_memalign mapping"
+    default 64
+    ---help---
+        This option sets the size for the posix_memalign mapping when
+        bypassing libc to use NuttX system calls.
+
+endif

--- a/libc_bypass/Make.defs
+++ b/libc_bypass/Make.defs
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ifneq ($(CONFIG_WASM_LIBC_BYPASS),)
+CONFIGURED_APPS += $(APPDIR)/frameworks/runtimes/wasm/libc_bypass
+endif # CONFIG_WASM_LIBC_BYPASS

--- a/libc_bypass/Makefile
+++ b/libc_bypass/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include $(APPDIR)/Make.defs
+
+IWASM_ROOT := $(APPDIR)/interpreters/wamr
+
+CSRCS += libc_bypass.c
+
+#Filter compilation warnings for syscall library
+CFLAGS += -Wno-unused-variable -Wno-int-conversion
+
+WAMR_MODULE_NAME = libc_bypass
+
+
+GLUECSRCS = syscall_glue.c libc_glue.c libm_glue.c
+CSVSRCS = $(TOPDIR)/syscall/syscall.csv $(TOPDIR)/libs/libc/libc.csv $(TOPDIR)/libs/libm/libm.csv
+
+$(GLUECSRCS): $(CSVSRCS) ../tools/mkwamrglue.py
+	$(Q) ../tools/mkwamrglue.py -i $(TOPDIR)/syscall/syscall.csv -o syscall_glue.c
+	$(Q) ../tools/mkwamrglue.py -i $(TOPDIR)/libs/libc/libc.csv -o libc_glue.c
+	$(Q) ../tools/mkwamrglue.py -i $(TOPDIR)/libs/libm/libm.csv -o libm_glue.c
+	gcc -shared -fPIC -o signature_libc.so signature_libc_glue.c -I$(IWASM_ROOT)
+	gcc -shared -fPIC -o signature_libm.so signature_libm_glue.c -I$(IWASM_ROOT)
+	gcc -shared -fPIC -o signature_syscall.so signature_syscall_glue.c -I$(IWASM_ROOT)
+
+depend:: $(GLUECSRCS)
+
+distclean::
+	$(call DELFILE, syscall_glue.c)
+	$(call DELFILE, libc_glue.c)
+	$(call DELFILE, libm_glue.c)
+
+include $(APPDIR)/interpreters/wamr/Module.mk
+include $(APPDIR)/Application.mk

--- a/libc_bypass/libc_bypass.c
+++ b/libc_bypass/libc_bypass.c
@@ -1,0 +1,553 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <iconv.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "wasm_export.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static sem_t g_aligned_memory_map_sem = SEM_INITIALIZER(1);
+static uintptr_t g_aligned_memory_map
+    [CONFIG_LIBC_BYPASS_POSIXMEMALIGN_MAP_SIZE][2]
+    = {
+          0
+      };
+
+static bool
+add_to_aligned_map(uintptr_t mapped, uintptr_t raw)
+{
+    int i;
+    bool ret = false;
+    sem_wait(&g_aligned_memory_map_sem);
+    for (i = 0; i < CONFIG_LIBC_BYPASS_POSIXMEMALIGN_MAP_SIZE;
+         i++) {
+        DEBUGASSERT(g_aligned_memory_map[i][0] != mapped);
+        if (g_aligned_memory_map[i][0] == 0 && g_aligned_memory_map[i][1] == 0) {
+            g_aligned_memory_map[i][0] = mapped;
+            g_aligned_memory_map[i][1] = raw;
+            ret = true;
+            break;
+        }
+    }
+    sem_post(&g_aligned_memory_map_sem);
+    return ret;
+}
+
+static uintptr_t
+remove_from_aligned_map(uintptr_t mapped)
+{
+    int i;
+    uintptr_t ret = 0;
+    if (mapped == 0) {
+        return ret;
+    }
+    sem_wait(&g_aligned_memory_map_sem);
+    for (i = 0; i < CONFIG_LIBC_BYPASS_POSIXMEMALIGN_MAP_SIZE;
+         i++) {
+        if (g_aligned_memory_map[i][0] == mapped) {
+            g_aligned_memory_map[i][0] = 0;
+            ret = g_aligned_memory_map[i][1];
+            g_aligned_memory_map[i][1] = 0;
+            break;
+        }
+    }
+    sem_post(&g_aligned_memory_map_sem);
+    return ret;
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void
+va_list_string2conv(wasm_exec_env_t exec_env, const char* format,
+    va_list ap, bool to_native)
+{
+    wasm_module_inst_t module_inst = get_module_inst(exec_env);
+    char* pos = *((char**)&ap);
+    if (pos == NULL) {
+        return;
+    }
+    int long_ctr = 0;
+    int might = 0;
+    while (*format) {
+        if (!might) {
+            if (*format == '%') {
+                might = 1;
+                long_ctr = 0;
+            }
+        } else {
+            switch (*format) {
+            case '.':
+            case '+':
+            case '-':
+            case ' ':
+            case '#':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                goto still_might;
+            case 't':
+            case 'z':
+                long_ctr = 1;
+                goto still_might;
+            case 'j':
+                long_ctr = 2;
+                goto still_might;
+            case 'l':
+                long_ctr++;
+            case 'h':
+                goto still_might;
+            case 'o':
+            case 'd':
+            case 'i':
+            case 'u':
+            case 'p':
+            case 'x':
+            case 'X':
+            case 'c': {
+                if (long_ctr < 2) {
+                    pos += sizeof(int32_t);
+                } else {
+                    pos += sizeof(int64_t);
+                }
+                break;
+            }
+            case 'e':
+            case 'E':
+            case 'g':
+            case 'G':
+            case 'f':
+            case 'F': {
+                pos += sizeof(double);
+                break;
+            }
+            case 's': {
+                if (to_native) {
+                    *(uintptr_t*)pos = (uintptr_t)addr_app_to_native(*(uintptr_t*)pos);
+                } else {
+                    *(uintptr_t*)pos = (uintptr_t)addr_native_to_app(*(uintptr_t*)pos);
+                }
+                pos += sizeof(uintptr_t);
+                break;
+            }
+            default:
+                break;
+            }
+            might = 0;
+        }
+    still_might:
+        ++format;
+    }
+}
+
+#define va_list_string2native(exec_env, format, ap) \
+    va_list_string2conv(exec_env, format, ap, true)
+#define va_list_string2app(exec_env, format, ap) \
+    va_list_string2conv(exec_env, format, ap, false)
+
+static void
+scanf_begin(wasm_module_inst_t module_inst, va_list ap)
+{
+    uintptr_t* apv = *(uintptr_t**)&ap;
+    if (apv == NULL) {
+        return;
+    }
+    while (*apv != 0) {
+        *apv = (uintptr_t)addr_app_to_native(*apv);
+        apv++;
+    }
+}
+
+static void
+scanf_end(wasm_module_inst_t module_inst, va_list ap)
+{
+    uintptr_t* apv = *(uintptr_t**)&ap;
+    if (apv == NULL) {
+        return;
+    }
+    while (*apv != 0) {
+        *apv = (uintptr_t)addr_native_to_app((void*)*apv);
+        apv++;
+    }
+}
+
+static pthread_mutex_t g_compare_mutex = PTHREAD_MUTEX_INITIALIZER;
+static wasm_exec_env_t g_compare_env;
+static void* g_compare_func;
+
+static int
+compare_proxy(const void* a, const void* b)
+{
+    wasm_module_inst_t module_inst = get_module_inst(g_compare_env);
+    uint32_t argv[2];
+    argv[0] = addr_native_to_app((void*)a);
+    argv[1] = addr_native_to_app((void*)b);
+    return wasm_runtime_call_indirect(g_compare_env,
+               (uint32_t)addr_native_to_app(g_compare_func), 2, argv)
+        ? argv[0]
+        : 0;
+}
+
+#ifndef GLUE_FUNCTION_qsort
+#define GLUE_FUNCTION_qsort
+void glue_qsort(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2,
+    uintptr_t parm3, uintptr_t parm4)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    pthread_mutex_lock(&g_compare_mutex);
+    g_compare_env = env;
+    g_compare_func = parm4;
+    qsort((FAR void*)parm1, (size_t)parm2,
+        (size_t)parm3, compare_proxy);
+    pthread_mutex_unlock(&g_compare_mutex);
+}
+#endif /* GLUE_FUNCTION_qsort */
+
+#ifndef GLUE_FUNCTION_bsearch
+#define GLUE_FUNCTION_bsearch
+uintptr_t glue_bsearch(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2,
+    uintptr_t parm3, uintptr_t parm4, uintptr_t parm5)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    pthread_mutex_lock(&g_compare_mutex);
+    g_compare_env = env;
+    g_compare_func = parm5;
+    ret = bsearch((FAR const void*)parm1,
+        (FAR const void*)parm2,
+        (size_t)parm3, (size_t)parm4, compare_proxy);
+    pthread_mutex_unlock(&g_compare_mutex);
+    ret = addr_native_to_app((void*)ret);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_bsearch */
+
+static void glue_msghdr_begin(wasm_module_inst_t module_inst,
+    FAR struct msghdr* hdr)
+{
+    int i;
+    hdr->msg_iov = addr_app_to_native((uintptr_t)hdr->msg_iov);
+    for (i = 0; i < hdr->msg_iovlen; i++) {
+        hdr->msg_iov[i].iov_base = addr_app_to_native((uintptr_t)hdr->msg_iov[i].iov_base);
+    }
+    if (hdr->msg_name != NULL && hdr->msg_namelen > 0) {
+        hdr->msg_name = addr_app_to_native(hdr->msg_name);
+    }
+    if (hdr->msg_control != NULL && hdr->msg_controllen > 0) {
+        hdr->msg_control = addr_app_to_native((uintptr_t)hdr->msg_control);
+    }
+}
+
+static void glue_msghdr_end(wasm_module_inst_t module_inst,
+    FAR struct msghdr* hdr)
+{
+    int i;
+    for (i = 0; i < hdr->msg_iovlen; i++) {
+        hdr->msg_iov[i].iov_base = addr_native_to_app((uintptr_t)hdr->msg_iov[i].iov_base);
+    }
+    hdr->msg_iov = addr_native_to_app((uintptr_t)hdr->msg_iov);
+    if (hdr->msg_name != NULL && hdr->msg_namelen > 0) {
+        hdr->msg_name = addr_native_to_app(hdr->msg_name);
+    }
+    if (hdr->msg_control != NULL && hdr->msg_controllen > 0) {
+        hdr->msg_control = addr_native_to_app((uintptr_t)hdr->msg_control);
+    }
+}
+
+#ifndef GLUE_FUNCTION_sendmsg
+#define GLUE_FUNCTION_sendmsg
+uintptr_t glue_sendmsg(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t parm2, uintptr_t parm3)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    FAR struct msghdr* hdr = (FAR struct msghdr*)(uintptr_t)parm2;
+    glue_msghdr_begin(module_inst, hdr);
+    uintptr_t ret = sendmsg((int)parm1,
+        (FAR struct msghdr*)(parm2),
+        (int)parm3);
+    glue_msghdr_end(module_inst, hdr);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_sendmsg */
+
+#ifndef GLUE_FUNCTION_recvmsg
+#define GLUE_FUNCTION_recvmsg
+uintptr_t glue_recvmsg(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t parm2, uintptr_t parm3)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    FAR struct msghdr* hdr = (FAR struct msghdr*)((uintptr_t)parm2);
+    glue_msghdr_begin(module_inst, hdr);
+    uintptr_t ret = recvmsg((int)parm1,
+        (FAR struct msghdr*)(parm2),
+        (int)parm3);
+    glue_msghdr_end(module_inst, hdr);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_recvmsg */
+
+#ifndef GLUE_FUNCTION_strsep
+#define GLUE_FUNCTION_strsep
+uintptr_t glue_strsep(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    FAR char** stringp = parm1;
+    if (*stringp != NULL) {
+        *stringp = addr_app_to_native(*stringp);
+    }
+    return addr_native_to_app((uintptr_t)strsep(
+        (FAR char**)addr_app_to_native(parm1),
+        (FAR const char*)addr_app_to_native(parm2)));
+}
+#endif /* GLUE_FUNCTION_strsep */
+
+#ifndef GLUE_FUNCTION_scandir
+#define GLUE_FUNCTION_scandir
+uintptr_t glue_scandir(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2,
+    uintptr_t parm3, uintptr_t parm4)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    int ret = 0;
+    int i = 0;
+    ret = scandir((FAR const char*)parm1,
+        (FAR struct dirent***)parm2,
+        (FAR void*)parm3, alphasort);
+    for (i = 0; i < ret; i++) {
+        (*(uintptr_t**)parm2)[i] = addr_native_to_app((*(uintptr_t**)parm2)[i]);
+    }
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_scandir */
+
+#ifndef GLUE_FUNCTION_daemon
+#define GLUE_FUNCTION_daemon
+uintptr_t glue_daemon(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2)
+{
+    return 0;
+}
+#endif /* GLUE_FUNCTION_daemon */
+
+#ifndef GLUE_FUNCTION_posix_memalign
+#define GLUE_FUNCTION_posix_memalign
+uintptr_t glue_posix_memalign(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t parm2, uintptr_t parm3)
+{
+    uintptr_t rawptr;
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    /* Extra size for align */
+    parm3 += parm2;
+    int ret = posix_memalign((FAR void**)parm1, (size_t)parm2, (size_t)parm3);
+    /* If the memory allocation is failed, return NULL */
+    if (ret != OK) {
+        return NULL;
+    }
+    /* Add the original pointer to the map */
+    rawptr = *(uintptr_t*)parm1;
+    *(void**)parm1 = addr_native_to_app((uintptr_t) * (void**)parm1);
+    *(uintptr_t*)parm1 = (*(uintptr_t*)parm1 + parm2 - 1) & ~(parm2 - 1);
+    if (add_to_aligned_map(*(uintptr_t*)parm1, rawptr)) {
+        return ret;
+    } else {
+        free(rawptr);
+        return NULL;
+    }
+}
+#endif /* GLUE_FUNCTION_posix_memalign */
+
+#ifndef GLUE_FUNCTION_free
+#define GLUE_FUNCTION_free
+void glue_free(wasm_exec_env_t env, uintptr_t parm1)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret = NULL;
+    uintptr_t app_addr = NULL;
+    /* Try to pop the original pointer from the map */
+    if (parm1 != (uintptr_t)NULL) {
+        app_addr = addr_native_to_app(parm1);
+        ret = remove_from_aligned_map(app_addr);
+    }
+    if (ret) {
+        parm1 = ret;
+    }
+    free((FAR void*)parm1);
+}
+#endif /* GLUE_FUNCTION_free */
+
+#ifndef GLUE_FUNCTION_vasprintf
+#define GLUE_FUNCTION_vasprintf
+uintptr_t glue_vasprintf(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t format, va_list ap)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    va_list_string2native(env, format, ap);
+    ret = vasprintf((FAR char**)parm1, (FAR const IPTR char*)format, ap);
+    *(uintptr_t*)parm1 = addr_native_to_app(*(uintptr_t*)parm1);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_vasprintf */
+
+#ifndef GLUE_FUNCTION_strtol
+#define GLUE_FUNCTION_strtol
+uintptr_t glue_strtol(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2,
+    uintptr_t parm3)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    *(uintptr_t*)parm2 = addr_app_to_native(*(uintptr_t*)parm2);
+    ret = strtol((FAR const char*)parm1, (FAR char**)parm2, (int)parm3);
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_strtol */
+
+#if defined(CONFIG_HAVE_LONG_LONG)
+#ifndef GLUE_FUNCTION_strtoll
+#define GLUE_FUNCTION_strtoll
+uintptr_t glue_strtoll(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2,
+    uintptr_t parm3)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    *(uintptr_t*)parm2 = addr_app_to_native(*(uintptr_t*)parm2);
+    ret = strtoll((FAR const char*)parm1, (FAR char**)parm2, (int)parm3);
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_strtoll */
+#endif
+
+#ifndef GLUE_FUNCTION_strtoul
+#define GLUE_FUNCTION_strtoul
+uintptr_t glue_strtoul(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t parm2, uintptr_t parm3)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    *(uintptr_t*)parm2 = addr_app_to_native(*(uintptr_t*)parm2);
+    ret = strtoul((FAR const char*)parm1, (FAR char**)parm2, (int)parm3);
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_strtoul */
+
+#ifndef GLUE_FUNCTION_strtoull
+#define GLUE_FUNCTION_strtoull
+uintptr_t glue_strtoull(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t parm2, uintptr_t parm3)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    *(uintptr_t*)parm2 = addr_app_to_native(*(uintptr_t*)parm2);
+    ret = strtoull((FAR const char*)parm1, (FAR char**)parm2, (int)parm3);
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_strtoull */
+
+#if defined(CONFIG_LIBC_LOCALE)
+#ifndef GLUE_FUNCTION_iconv
+#define GLUE_FUNCTION_iconv
+uintptr_t glue_iconv(wasm_exec_env_t env, uintptr_t parm1, uintptr_t parm2,
+    uintptr_t parm3, uintptr_t parm4, uintptr_t parm5)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    *(uintptr_t*)parm2 = addr_app_to_native(*(uintptr_t*)parm2);
+    *(uintptr_t*)parm4 = addr_app_to_native(*(uintptr_t*)parm4);
+    ret = iconv((iconv_t)parm1, (FAR char**)parm2, (FAR size_t*)parm3,
+        (FAR char**)parm4, (FAR size_t*)parm5);
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    *(uintptr_t*)parm4 = addr_native_to_app(*(uintptr_t*)parm4);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_iconv */
+#endif /* defined(CONFIG_LIBC_LOCALE) */
+
+#ifndef GLUE_FUNCTION_versionsort
+#define GLUE_FUNCTION_versionsort
+uintptr_t glue_versionsort(wasm_exec_env_t env, uintptr_t parm1,
+    uintptr_t parm2)
+{
+    wasm_module_inst_t module_inst = get_module_inst(env);
+    uintptr_t ret;
+    *(uintptr_t*)parm1 = addr_app_to_native(*(uintptr_t*)parm1);
+    *(uintptr_t*)parm2 = addr_app_to_native(*(uintptr_t*)parm2);
+    ret = versionsort((FAR const struct dirent**)parm1,
+        (FAR const struct dirent**)parm2);
+    *(uintptr_t*)parm1 = addr_native_to_app(*(uintptr_t*)parm1);
+    *(uintptr_t*)parm2 = addr_native_to_app(*(uintptr_t*)parm2);
+    return ret;
+}
+#endif /* GLUE_FUNCTION_versionsort */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "libc_glue.c"
+#include "libm_glue.c"
+#include "syscall_glue.c"
+
+/* Register module, this function is called by the WAMR runtime */
+
+bool wamr_module_libc_bypass_register(void)
+{
+    bool ret;
+
+    /* Add extra init hook here */
+
+    ret = wasm_runtime_register_natives("env", g_syscall_native_symbols, nitems(g_syscall_native_symbols));
+    if (!ret) {
+        return ret;
+    }
+
+    ret = wasm_runtime_register_natives("env", g_libc_native_symbols, nitems(g_libc_native_symbols));
+    if (!ret) {
+        return ret;
+    }
+
+    ret = wasm_runtime_register_natives("env", g_libm_native_symbols, nitems(g_libm_native_symbols));
+    if (!ret) {
+        return ret;
+    }
+
+    return ret;
+}

--- a/tools/mkwamrglue.py
+++ b/tools/mkwamrglue.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+############################################################################
+# apps/tools/mkwamrglue.py
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import argparse
+import os
+import sys
+
+NAME_INDEX = 0
+HEADER_INDEX = 1
+COND_INDEX = 2
+RETTYPE_INDEX = 3
+PARM1_INDEX = 4
+
+POINTER_SIGNATURE = ['...', '*', '_sa_handler_t', ',mbstate_t']
+
+BLACK_LIST = ['sigqueue', 'pthread_create', 'pthread_detach',
+              'pthread_key_create', 'pthread_key_delete', 'pthread_getspecific',
+              'pthread_setspecific', 'mallinfo', 'inet_ntoa', 'crypt', 'crypt_r']
+
+VA_ADDITIONAL_FUNCS = [
+    'asprintf', 'fprintf', 'fscanf', 'printf', 'snprintf', 'sprintf',
+    'sprintf', 'sscanf', 'sscanf', 'swprintf', 'syslog',
+]
+
+VA_LIST_FUNCS = [
+    'vasprintf', 'vfprintf', 'vprintf', 'vscanf', 'vsnprintf', 'vsprintf',
+    'vsscanf', 'vsyslog',
+]
+
+
+def is_strip_function(name):
+  for black in BLACK_LIST:
+    if black == name:
+      return True
+
+  return False
+
+
+def is_va_additional_function(name):
+  for va in VA_ADDITIONAL_FUNCS:
+    if va == name:
+      return True
+
+  return False
+
+
+def is_va_list_function(name):
+  for va in VA_LIST_FUNCS:
+    if va == name:
+      return True
+
+  return False
+
+
+def generate_include(csv, out):
+  headers = []
+  for line in csv.readlines():
+    sline = line.strip()
+    if sline == '':
+      break
+    args = []
+    for arg in sline.split(","):
+      args.append(arg.strip().strip('\"'))
+
+    if is_strip_function(args[NAME_INDEX]):
+      continue
+
+    if len(args[HEADER_INDEX]) != 0 and args[HEADER_INDEX] not in headers:
+      headers.append(args[HEADER_INDEX])
+
+  headers.sort()
+
+  for header in headers:
+    out.write(f"#include <{header}>\n")
+
+  out.write("\n")
+  out.write("#include <wasm_export.h>\n")
+  out.write("\n")
+  csv.seek(0)
+
+
+def generate_functions(csv, out, lib):
+  for line in csv.readlines():
+    sline = line.strip()
+    if sline == '':
+      break
+    args = []
+    # Source data: "qsort","stdlib.h","","void","FAR void *","size_t","size_t","int(*)(FAR const void *,FAR const void *)"
+    # After split：
+    # 1."qsort  2."stdlib.h 3." 4."void 5."FAR void *
+    # 6."size_t 7."size_t 8."int(*)(FAR const void *,FAR const void *)
+    for arg in sline.split("\","):
+      args.append(arg.strip().strip('\"'))
+
+    if is_strip_function(args[NAME_INDEX]):
+      continue
+
+    nodef = (len(args[COND_INDEX]) != 0)
+    if nodef:
+      out.write("#if " + args[COND_INDEX] + "\n\n")
+
+    out.write(f"#ifndef GLUE_FUNCTION_{args[NAME_INDEX]}\n")
+    out.write(f"#define GLUE_FUNCTION_{args[NAME_INDEX]}\n")
+
+    noreturn = args[RETTYPE_INDEX] == 'void' or \
+        args[RETTYPE_INDEX] == 'noreturn'
+
+    if noreturn:
+      out.write(f"void glue_{args[NAME_INDEX]}(wasm_exec_env_t env")
+    else:
+      out.write(f"uintptr_t glue_{args[NAME_INDEX]}(wasm_exec_env_t env")
+
+    if is_va_additional_function(args[NAME_INDEX]):
+      findex = len(args) - 2
+      vprefix = 'v'
+    elif is_va_list_function(args[NAME_INDEX]):
+      findex = len(args) - 2
+    else:
+      findex = 0
+      vprefix = ''
+
+    for index in range(PARM1_INDEX, len(args)):
+      if findex == index:
+        out.write(", uintptr_t format")
+      elif args[index] == '...':
+        out.write(", va_list ap")
+        break
+      elif args[index] == 'va_list' and findex != 0:
+        out.write(", va_list ap")
+        break
+      elif args[index] == 'void':
+        continue
+      else:
+        out.write(f", uintptr_t parm{index - PARM1_INDEX + 1}")
+
+    out.write(")\n{\n")
+
+    addrcov = False
+    for index in range(PARM1_INDEX, len(args)):
+      if '*' in args[index] or 'va_list' in args[index] or '...' in args[index]:
+        addrcov = True
+
+    if addrcov == False and '*' in args[RETTYPE_INDEX]:
+      addrcov = True
+
+    out.write("  wasm_module_inst_t module_inst = get_module_inst(env);\n")
+    out.write("  uintptr_t ret;\n")
+
+    if findex != 0:
+      if 'scanf' in args[NAME_INDEX]:
+        out.write("  scanf_begin(module_inst, ap);\n")
+      else:
+        out.write("  va_list_string2native(env, format, ap);\n")
+
+    if noreturn:
+      noret = ''
+    else:
+      noret = 'return'
+
+    addrcov = ''
+    if '*' in args[RETTYPE_INDEX]:
+      addrcov = 'addr_native_to_app((uintptr_t)'
+
+    if noreturn:
+      out.write(f"  {addrcov}{vprefix}{args[NAME_INDEX]}(")
+    else:
+      out.write(f"  ret = {addrcov}{vprefix}{args[NAME_INDEX]}(")
+
+    for index in range(PARM1_INDEX, len(args)):
+      if index > PARM1_INDEX:
+        out.write(", ")
+      if args[index] == '...':
+        if index < len(args) - 1 and args[NAME_INDEX] == 'ioctl':
+          out.write(
+              f"(*(uintptr_t **)&ap != NULL && **(uintptr_t **)&ap != (uintptr_t)NULL) ? (uintptr_t)addr_app_to_native((uintptr_t)va_arg(ap, {args[index + 1]})) : (uintptr_t)NULL")
+        elif index < len(args) - 1:
+          out.write(
+              f"(*(uintptr_t **)&ap != NULL && **(uintptr_t **)&ap != (uintptr_t)NULL) ? (uintptr_t)va_arg(ap, {args[index + 1]}) : (uintptr_t)NULL")
+        else:
+          out.write("ap")
+        break
+      if args[index] == 'va_list' and findex != 0:
+        out.write("ap")
+        break
+      if args[index] == 'void':
+        continue
+      if '|' in args[index]:
+        args[index] = args[index].split("|")[1]
+      if findex == index:
+        out.write(f"({args[index]})format")
+      else:
+        out.write(f"({args[index]})parm{index - PARM1_INDEX + 1}")
+
+    if addrcov != '':
+      out.write(")")
+
+    out.write(");\n")
+
+    if findex != 0:
+      if 'scanf' in args[NAME_INDEX]:
+        out.write("  scanf_end(module_inst, ap);\n")
+      else:
+        out.write("  va_list_string2app(env, format, ap);\n")
+
+    if noreturn:
+      pass
+    else:
+      out.write("  return ret;\n")
+
+    out.write("}\n\n")
+
+    out.write(f"#endif /* GLUE_FUNCTION_{args[NAME_INDEX]} */\n")
+
+    if nodef:
+      out.write(f"#endif /* {args[COND_INDEX]} */\n\n")
+  csv.seek(0)
+
+
+def generate_table(csv, out, lib):
+  out.write("#ifndef native_function\n")
+  out.write("#define native_function(func_name, signature) \\\n")
+  out.write("  { #func_name, glue_##func_name, signature, NULL }\n\n")
+  out.write("#endif\n")
+
+  lib.write("static void empty_stub(void) {}\n\n")
+  lib.write("#ifndef native_function\n")
+  lib.write("#define native_function(func_name, signature) \\\n")
+  lib.write("  { #func_name, empty_stub, signature, NULL }\n\n")
+  lib.write("#endif\n")
+
+  out.write(f"static NativeSymbol g_{os.path.splitext(os.path.basename(csv.name))[0]}_native_symbols[] =\n")
+  lib.write(f"static NativeSymbol g_{os.path.splitext(os.path.basename(csv.name))[0]}_native_symbols[] =\n")
+  out.write("{\n")
+  lib.write("{\n")
+
+  for line in csv.readlines():
+    sline = line.strip()
+    if sline == '':
+      break
+    args = []
+    for arg in sline.split("\","):
+      args.append(arg.strip().strip('\"'))
+
+    if is_strip_function(args[NAME_INDEX]):
+      continue
+
+    nodef = (len(args[COND_INDEX]) != 0)
+    if nodef:
+      out.write("#if " + args[COND_INDEX] + "\n")
+
+    out.write(f"#ifndef GLUE_ENTRY_{args[NAME_INDEX]}\n")
+    out.write(f"#define GLUE_ENTRY_{args[NAME_INDEX]}\n")
+
+    out.write(f"  native_function({args[NAME_INDEX]},\"(")
+    lib.write(f"  native_function({args[NAME_INDEX]},\"(")
+
+    noreturn = args[RETTYPE_INDEX] == 'void' or \
+        args[RETTYPE_INDEX] == 'noreturn'
+
+    signature = ''
+
+    for index in range(PARM1_INDEX, len(args)):
+      if '(*)' in args[index]:
+        signature += 'i'
+      elif 'float' in args[index]:
+        signature += 'f'
+      elif 'double' in args[index]:
+        signature += 'F'
+      elif 'long long' in args[index]:
+        signature += 'I'
+      elif 'char *' in args[index]:
+        signature += '$'
+      elif 'off_t' in args[index]:
+        signature += 'I'
+      elif 'uintptr_t' in args[index]:
+        signature += 'i'
+      elif 'va_list' in args[index]:
+        signature += '*'
+      else:
+        defval = True
+        for sig in POINTER_SIGNATURE:
+          if sig in args[index]:
+            signature += '*'
+            defval = False
+            break
+
+        if defval:
+          signature += 'i'
+        if '...' in args[index]:
+          break
+
+    out.write(signature)
+    lib.write(signature)
+
+    out.write(")")
+    lib.write(")")
+
+    retval = ''
+
+    if not noreturn:
+      if '*' in args[RETTYPE_INDEX]:
+        retval = 'i'
+      elif 'off_t' in args[RETTYPE_INDEX]:
+        retval = 'I'
+      elif 'time_t' in args[RETTYPE_INDEX]:
+        retval = 'I'
+      elif 'double' in args[RETTYPE_INDEX]:
+        retval = 'F'
+      elif 'float' in args[RETTYPE_INDEX]:
+        retval = 'f'
+      elif 'long long' in args[RETTYPE_INDEX]:
+        retval = 'I'
+      else:
+        retval = 'i'
+
+    out.write(retval)
+    lib.write(retval)
+
+    out.write("\"),\n")
+    lib.write("\"),\n")
+
+    out.write(f"#endif /* GLUE_ENTRY_{args[NAME_INDEX]} */\n")
+
+    if nodef:
+      out.write(f"#endif /* {args[COND_INDEX]} */\n\n")
+
+  out.write("};\n")
+  lib.write("};\n")
+
+  lib.write("\n")
+  lib.write("uint32_t get_native_lib(char **p_module_name, NativeSymbol **p_base_lib_apis) {\n")
+  lib.write(f"  *p_module_name = \"env\";\n")
+  lib.write(f"  *p_base_lib_apis = g_{os.path.splitext(os.path.basename(csv.name))[0]}_native_symbols;\n")
+  lib.write(f"  return sizeof(g_{os.path.splitext(os.path.basename(csv.name))[0]}_native_symbols) / sizeof(NativeSymbol);\n")
+  lib.write("}\n\n")
+
+  csv.seek(0)
+
+
+def generate_glue(csv, out, lib):
+  generate_include(csv, out)
+  generate_functions(csv, out, lib)
+  generate_table(csv, out, lib)
+
+
+def parse_args():
+  global args
+  parser = argparse.ArgumentParser(
+      description=__doc__,
+      formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
+  parser.add_argument("-i", "--input", required=True,
+                      help="CSV(Comma-Separated-Value) file")
+  parser.add_argument(
+      "-o", "--output", help="Output header file", default="glue.c")
+  parser.add_argument("-v", "--verbose", action="count", default=0,
+                      help="Verbose Output")
+  args = parser.parse_args()
+
+
+def main():
+  parse_args()
+  if not os.path.isfile(args.input):
+    sys.exit(1)
+
+  infile = open(args.input, "r")
+  outfile = open(args.output, "w")
+  libfile = open(f"signature_{args.output}", "w")
+
+  outfile.write("#include <nuttx/config.h>\n")
+  outfile.write("#include <stdint.h>\n")
+
+  libfile.write("#include <stdarg.h>\n")
+  libfile.write("#include <stddef.h>\n")
+  libfile.write("#include \"wamr/core/iwasm/include/lib_export.h\"\n\n")
+
+  generate_glue(infile, outfile, libfile)
+
+  infile.close()
+  outfile.close()
+  libfile.close()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION

## Summary

*Relocated the libc nuttx implementation from apps/ to frameworks/.
Updated all relevant include paths and build system references.
Maintained existing functionality while improving code organization.
Related:https://github.com/open-vela/nuttx-apps/pull/55*

## Impact

*Build system configurations need to be updated to reflect new location.
No functional changes to the libc implementation itself.*

## Testing

*Verified all unit tests pass with new location.
Built and tested sample applications using the moved library.
Confirmed no regression in existing functionality.
Checked cross-platform compatibility.*

