### PR TITLE
frameworks/wasm: Add kvdb missing interface in frameworks

### DIFF
--- a/kvdb/CMakeLists.txt
+++ b/kvdb/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ##############################################################################
+# apps/frameworks/chre/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_KVDB AND CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY)
+
+  target_sources(apps PRIVATE kvdb.c)
+  # register WAMR mod
+  nuttx_add_wamrmod(MODS kvdb)
+endif()

--- a/kvdb/Make.defs
+++ b/kvdb/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/frameworks/runtimes/wasm/chre/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_KVDB)$(CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY),yy)
+CONFIGURED_APPS += $(APPDIR)/frameworks/runtimes/wasm/kvdb
+endif

--- a/kvdb/Makefile
+++ b/kvdb/Makefile
@@ -1,0 +1,35 @@
+############################################################################
+# apps/frameworks/wasm/chre/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+CSRCS += kvdb.c
+
+# To delete the Kconfig file, an empty preconfig needs to be added.
+preconfig::
+
+# Set WAMR_MODULE_NAME and include Module.mk to add this module to the list of
+# builtin modules for the WAMR runtime. WAMR_MODULE_NAME must be unique across all
+# modules in system.
+
+WAMR_MODULE_NAME = kvdb
+
+include $(APPDIR)/interpreters/wamr/Module.mk
+include $(APPDIR)/Application.mk

--- a/kvdb/kvdb.c
+++ b/kvdb/kvdb.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corperation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <sys/param.h>
+
+#include "kvdb.h"
+#include "wasm_export.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int property_set_buffer_wrapper(wasm_exec_env_t env,
+    const char* key,
+    const void* value,
+    size_t size)
+{
+    return property_set_buffer(key, value, size);
+}
+
+static NativeSymbol g_kvdb_symbols[] = {
+    EXPORT_WASM_API_WITH_SIG2(property_set_buffer, "($*i)i"),
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+bool wamr_module_kvdb_register(void)
+{
+    /* Add frameworks section init hook here */
+
+    return wasm_runtime_register_natives("env", g_kvdb_symbols,
+        nitems(g_kvdb_symbols));
+}


### PR DESCRIPTION
## Summary

frameworks/wasm: Add kvdb missing interface in frameworks

## Impact

no impact

## Testing

local test passed

