### PR TITLE
wasm/libc_bypass: add cmake compilation

### DIFF
--- a/libc_bypass/CMakeLists.txt
+++ b/libc_bypass/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_WASM_LIBC_BYPASS)
+  add_custom_target(
+    gen_glue_sources
+    COMMAND ${NUTTX_APPS_DIR}/../frameworks/runtimes/wasm/tools/mkwamrglue.py -i
+            ${NUTTX_DIR}/syscall/syscall.csv -o syscall_glue.c
+    COMMAND ${NUTTX_APPS_DIR}/../frameworks/runtimes/wasm/tools/mkwamrglue.py -i
+            ${NUTTX_DIR}/libs/libc/libc.csv -o libc_glue.c
+    COMMAND ${NUTTX_APPS_DIR}/../frameworks/runtimes/wasm/tools/mkwamrglue.py
+            -i ${NUTTX_DIR}/libs/libm/libm.csv -o libm_glue.c)
+
+  add_dependencies(apps_context gen_glue_sources)
+
+  if(NOT EXISTS {CMAKE_CURRENT_BINARY_DIR}/libc_bypass.c)
+    file(
+      COPY ${NUTTX_APPS_DIR}/frameworks/runtimes/wasm/libc_bypass/libc_bypass.c
+      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  endif()
+
+  # register WAMR mod
+  target_sources(apps PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/libc_bypass.c)
+  nuttx_add_wamrmod(MODS libc_bypass)
+
+endif()


### PR DESCRIPTION
## Summary

Add cmake compilation for libc wrappers

## Impact

Nop

## Testing

Enable the config CONFIG_WASM_LIBC_BYPASS and compile with cmake

